### PR TITLE
Adding NOT support

### DIFF
--- a/ext/bitset/bitset.c
+++ b/ext/bitset/bitset.c
@@ -234,6 +234,22 @@ static VALUE rb_bitset_xor(VALUE self, VALUE other) {
     return Data_Wrap_Struct(cBitset, 0, bitset_free, new_bs);
 }
 
+static VALUE rb_bitset_not(VALUE self) {
+    Bitset * bs = get_bitset(self);
+
+    Bitset * new_bs = bitset_new();
+    bitset_setup(new_bs, bs->len);
+
+    int max = ((bs->len-1) >> 6) + 1;
+    int i;
+    for(i = 0; i < max; i++) {
+        uint64_t segment = bs->data[i];
+        new_bs->data[i] = ~segment;
+    }
+
+    return Data_Wrap_Struct(cBitset, 0, bitset_free, new_bs);
+}
+
 static VALUE rb_bitset_hamming(VALUE self, VALUE other) {
     Bitset * bs = get_bitset(self);
     Bitset * other_bs = get_bitset(other);
@@ -283,6 +299,7 @@ void Init_bitset() {
     rb_define_method(cBitset, "xor", rb_bitset_xor, 1);
     rb_define_alias(cBitset, "^", "xor");
     rb_define_alias(cBitset, "symmetric_difference", "xor");
+    rb_define_method(cBitset, "not", rb_bitset_not, 0);
     rb_define_method(cBitset, "hamming", rb_bitset_hamming, 1);
     rb_define_method(cBitset, "each", rb_bitset_each, 0);
 }

--- a/ext/bitset/bitset.c
+++ b/ext/bitset/bitset.c
@@ -250,6 +250,36 @@ static VALUE rb_bitset_not(VALUE self) {
     return Data_Wrap_Struct(cBitset, 0, bitset_free, new_bs);
 }
 
+static VALUE rb_bitset_to_s(VALUE self) {
+    Bitset * bs = get_bitset(self);
+
+    int i;
+    char * data = malloc(bs->len + 1);
+    for(i = 0; i < bs->len; i++) {
+        data[i] = get_bit(bs, i)  ? '1' : '0';
+    }
+    data[bs->len] = 0;
+
+    return rb_str_new2(data);
+}
+
+static VALUE rb_bitset_from_s(VALUE self, VALUE s) {
+    int length = RSTRING(s)->len;
+    char* data = StringValuePtr(s);
+
+    Bitset * new_bs = bitset_new();
+    bitset_setup(new_bs, length);
+
+    int i;
+    for (i = 0; i < length; i++) {
+        if (data[i] == '1') {
+            set_bit(new_bs, i);
+        }
+    }
+
+    return Data_Wrap_Struct(cBitset, 0, bitset_free, new_bs);
+}
+
 static VALUE rb_bitset_hamming(VALUE self, VALUE other) {
     Bitset * bs = get_bitset(self);
     Bitset * other_bs = get_bitset(other);
@@ -302,4 +332,6 @@ void Init_bitset() {
     rb_define_method(cBitset, "not", rb_bitset_not, 0);
     rb_define_method(cBitset, "hamming", rb_bitset_hamming, 1);
     rb_define_method(cBitset, "each", rb_bitset_each, 0);
+    rb_define_method(cBitset, "to_s", rb_bitset_to_s, 0);
+    rb_define_singleton_method(cBitset, "from_s", rb_bitset_from_s, 1);
 }

--- a/spec/bitset_spec.rb
+++ b/spec/bitset_spec.rb
@@ -1,4 +1,4 @@
-require './bitset'
+require 'bitset'
 
 describe Bitset do
   it 'can be initialized' do
@@ -186,6 +186,17 @@ describe Bitset do
       bs3 = bs1 ^ bs2
       bs3.set?(2,6,7).should == true
       bs3.clear?(0,1,3,4,5).should == true
+    end
+  end
+
+  describe :not do
+    it "returns a new Bitset with is the not of one Bitset" do
+      bs1 = Bitset.new(8)
+      bs1.set 1, 4, 7
+
+      bs2 = bs1.not
+      bs2.set?(0, 2, 3, 5, 6).should == true
+      bs2.clear?(1, 4, 7).should == true
     end
   end
 

--- a/spec/bitset_spec.rb
+++ b/spec/bitset_spec.rb
@@ -225,4 +225,19 @@ describe Bitset do
       i.should == 4
     end
   end
+
+  describe :to_s do
+    it 'correctly prints out a binary string' do
+      bs = Bitset.new(4)
+      bs.set 0, 2
+      bs.to_s.should == "1010"
+    end
+  end
+
+  describe :from_s do
+    it 'correctly creates a bitmap from a binary string' do
+      bs = Bitset.from_s("10101")
+      bs.set?(0, 2, 4).should == true
+    end
+  end
 end


### PR DESCRIPTION
Hi,

This project is exactly what I've been looking for, but was missing bitwise not.  I've added it in a fork, but thought this would be useful to others.

One thing could still be done is to check for respond_to? :! and define an operator alias if Ruby 1.9 is detected.  This isn't important for me and I wasn't sure how do it from the C side anyway.

Regards,
Brendon.
