### PR TITLE
Add each_with_index and each_set_index methods

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ Jeweler::Tasks.new do |gem|
 end
 Jeweler::RubygemsDotOrgTasks.new
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/spec/bitset_spec.rb
+++ b/spec/bitset_spec.rb
@@ -235,6 +235,34 @@ describe Bitset do
     end
   end
 
+  describe :each_with_index do
+    it 'iterates over the bits in the Bitset and provides index' do
+      bs = Bitset.new(4)
+      bs.set 0, 2
+
+      i = 0
+      bs.each_with_index do |bit, idx|
+        bit.should == bs[i]
+        idx.should == i
+        i += 1
+      end
+      i.should == 4
+    end
+  end
+
+  describe :each_set_index do
+    it 'iterates over the set bits in the Bitset by index' do
+      bs = Bitset.new(100)
+      bs.set 0, 2, 8, 13, 17, 55, 88, 98
+
+      a = []
+      bs.each_set_index do |idx|
+        a << idx
+      end
+      a.should == [0, 2, 8, 13, 17, 55, 88, 98]
+    end
+  end
+
   describe :to_s do
     it 'correctly prints out a binary string' do
       bs = Bitset.new(4)


### PR DESCRIPTION
Hi @tyler!

I'd like to propose a couple new methods for this gem:

* `each_with_index` which provides the integer index as well as whether the bit is a 1 or 0. For many use cases, it's useful to know the index of the bit.
* `each_set_index` which efficiently iterates over only the 1's in the bit set.

Other changes:

* I also got a deprecation warning about `rdoctask` so I tweaked it to `rdoc/task`.
* `rb_bitset_marshall_load` and `rb_bitset_marshall_dump` are misspelled, should be `marshal`

Thanks for considering!